### PR TITLE
#6 add schema name

### DIFF
--- a/pgadmin_macros/function_get_column_info_table.sql
+++ b/pgadmin_macros/function_get_column_info_table.sql
@@ -50,12 +50,12 @@ SELECT
         concat(p.table_alias || '.', c.column_name), 
         ',' || chr(10)
         ORDER BY ordinal_position
-    ) || chr(10) || 'FROM ' || c.table_name || ' AS ' || p.table_alias  AS columns_new_line,
+    ) || chr(10) || 'FROM ' || c.table_schema || '.' || c.table_name || ' AS ' || p.table_alias  AS columns_new_line,
     'SELECT ' || string_agg(
         concat(p.table_alias || '.', c.column_name), 
         ','
         ORDER BY ordinal_position
-    ) || chr(10) || 'FROM ' || c.table_name || ' AS ' || p.table_alias  AS columns_no_new_line,
+    ) || chr(10) || 'FROM ' || c.table_schema || '.' || c.table_name || ' AS ' || p.table_alias  AS columns_no_new_line,
     string_agg(
         c.column_name, 
         ', '


### PR DESCRIPTION
A small bug fix to function `get_column_info_table`. Closes #6.
@chmnata I already tested the fix. Can you please update this one function in public schema?