### PR TITLE
#13 reverse order of dependency saving + add max_depth

### DIFF
--- a/create-function-deps_restore_dependencies.sql
+++ b/create-function-deps_restore_dependencies.sql
@@ -14,7 +14,7 @@ FOR v_curr IN (
     WHERE
         deps_view_schema = p_view_schema
         AND deps_view_name = p_view_name
-    ORDER BY deps_id ASC
+    ORDER BY deps_id DESC
 ) loop
 
 EXECUTE v_curr.deps_ddl_to_run;

--- a/create-function-deps_save_and_drop_dependencies.sql
+++ b/create-function-deps_save_and_drop_dependencies.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION public.deps_save_and_drop_dependencies(p_view_schema IN VARCHAR, p_view_name IN VARCHAR)
+CREATE OR REPLACE FUNCTION public.deps_save_and_drop_dependencies(p_view_schema IN VARCHAR, p_view_name IN VARCHAR, max_depth INTEGER)
 RETURNS VOID
 LANGUAGE SQL
     VOLATILE
@@ -8,14 +8,15 @@ AS $$
 SELECT public.deps_save_and_drop_dependencies_dryrun(
     p_view_schema,
     p_view_name,
-    False --dryrun = False
+    False, --dryrun = False
+    max_depth
 );
 $$;
 
-ALTER FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR) OWNER TO dbadmin;
-GRANT EXECUTE ON FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR) TO dbadmin;
+ALTER FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR, INTEGER) OWNER TO dbadmin;
+GRANT EXECUTE ON FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR, INTEGER) TO dbadmin;
 
-COMMENT ON FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR) IS 
+COMMENT ON FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR, INTEGER) IS 
     '''This version is only to be used by admins. It drops all dependencies of the inputed object. 
     Use this function when you need to drop+edit+recreate a table or (mat) view with dependencies.
     This function will recursively iterate through an objects dependencies and save:
@@ -31,9 +32,10 @@ COMMENT ON FUNCTION public.deps_save_and_drop_dependencies(VARCHAR, VARCHAR) IS
     public.deps_restore_dependencies(VARCHAR, VARCHAR) to recreate the dependencies. 
     You can also use `dryrun = True` to not drop the dependencies, if you want to check
     the entries in `public.deps_saved_ddl` first. 
+    max_depth parameter is used to prevent infinite recursion in cases where dependencies at one depth relative to the initial object reference each other. 
     
     Example:
-    SELECT public.deps_save_and_drop_dependencies(''miovision_api''::text COLLATE pg_catalog."C", ''volumes_15min''::text COLLATE pg_catalog."C");
+    SELECT public.deps_save_and_drop_dependencies(''miovision_api''::text COLLATE pg_catalog."C", ''volumes_15min''::text COLLATE pg_catalog."C", 20);
     --now DROP and make changes to miovision_api.volumes_15min, recreate. 
     SELECT public.deps_restore_dependencies(''miovision_api''::text COLLATE pg_catalog."C", ''volumes_15min''::text COLLATE pg_catalog."C");
     '''

--- a/create-function-deps_save_and_drop_dependencies_dryrun.sql
+++ b/create-function-deps_save_and_drop_dependencies_dryrun.sql
@@ -198,6 +198,8 @@ IF dryrun IS FALSE THEN
     END || ' ' || v_curr.obj_schema || '.' || v_curr.obj_name || ';';
 END IF;
 
+RAISE NOTICE 'Completed adding to public.deps_saved_ddl for %.% time=%', v_curr.obj_schema, v_curr.obj_name, timeofday();
+
 END loop;
 
 END;

--- a/create-function-deps_save_and_drop_dependencies_dryrun.sql
+++ b/create-function-deps_save_and_drop_dependencies_dryrun.sql
@@ -67,7 +67,7 @@ FOR v_curr IN
         WHERE depth > 0
     ) t
     GROUP BY obj_schema, obj_name, obj_type
-    ORDER BY max(depth) DESC
+    ORDER BY max(depth)
 ) loop
 
 IF v_curr.obj_type = 'v' THEN

--- a/create-function-deps_save_and_drop_dependencies_dryrun.sql
+++ b/create-function-deps_save_and_drop_dependencies_dryrun.sql
@@ -71,7 +71,7 @@ FOR v_curr IN
 ) loop
 
 --save comments on dependencies
-INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
 SELECT
     p_view_schema,
     p_view_name,
@@ -92,7 +92,7 @@ WHERE
     AND d.description is not null;
 
 --save comments on dependency columns
-INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
 SELECT
     p_view_schema,
     p_view_name,
@@ -110,7 +110,7 @@ WHERE
     AND d.description IS NOT NULL;
 
 --save permissions on object
-INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
 SELECT
     p_view_schema,
     p_view_name,
@@ -128,7 +128,7 @@ WHERE
 
 IF v_curr.obj_type = 'v' THEN
     --save view owners 
-    INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+    INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
     SELECT
         p_view_schema,
         p_view_name,
@@ -139,7 +139,7 @@ IF v_curr.obj_type = 'v' THEN
         schemaname = v_curr.obj_schema
         AND viewname = v_curr.obj_name;
 
-    INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+    INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
     --save view create statements
     SELECT
         p_view_schema,
@@ -154,7 +154,7 @@ IF v_curr.obj_type = 'v' THEN
 ELSIF v_curr.obj_type = 'm' THEN
 
     --save index/unique index: 
-    INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+    INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
     SELECT
         p_view_schema,
         p_view_name,
@@ -165,7 +165,7 @@ ELSIF v_curr.obj_type = 'm' THEN
         AND tablename = v_curr.obj_name;
 
     --save mat view owner: 
-    INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+    INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
     SELECT
         p_view_schema,
         p_view_name,
@@ -177,7 +177,7 @@ ELSIF v_curr.obj_type = 'm' THEN
         AND matviewname = v_curr.obj_name;
 
     --save mat view definition:
-    INSERT INTO gwolofs.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
+    INSERT INTO public.deps_saved_ddl(deps_view_schema, deps_view_name, deps_ddl_to_run)
     SELECT
         p_view_schema,
         p_view_name,

--- a/create-function-deps_save_and_drop_dependencies_dryrun.sql
+++ b/create-function-deps_save_and_drop_dependencies_dryrun.sql
@@ -227,7 +227,11 @@ COMMENT ON FUNCTION public.deps_save_and_drop_dependencies_dryrun(VARCHAR, VARCH
     - DROP the dependency (If dryrun = False)
     Then, after dropping, editing, and restoring the original object, use the function 
     public.deps_restore_dependencies(VARCHAR, VARCHAR) to recreate the dependencies. 
-    
+    `max_depth` parameter is used to prevent infinite recursion in cases where dependencies at one depth
+    relative to the initial object reference each other. May need to test with dryrun=True and increment the max_depth
+    to identify the required levels. Note that if this edge cases is true for your case, you may need to use dryrun = True and
+    manually order/the drop/add statements to correct for self-referential definitions at the same level. 
+
     Example with dryrun = True;
     SELECT public.deps_save_and_drop_dependencies_dryrun(''miovision_api''::text COLLATE pg_catalog."C", ''volumes_15min''::text COLLATE pg_catalog."C");
     --examine the create statements: 


### PR DESCRIPTION
Just a one line change to dependencies function.

**Testing**:
I recreated this function in my personal schema, which you can test with: 
(this example has 2 levels of dependencies so it's a good test case). 
```sql
SELECT gwolofs.deps_save_and_drop_dependencies_dryrun(
    'wys' COLLATE pg_catalog."C",
    'mobile_sign_installations' COLLATE pg_catalog."C"
);

SELECT deps_id, deps_view_schema, deps_view_name, deps_ddl_to_run
FROM gwolofs.deps_saved_ddl
WHERE 
    deps_view_schema = 'wys'
    AND deps_view_name = 'mobile_sign_installations';
```
We should also try running without dryrun on the example above. 