### PR TITLE
Update pgadmin macros: add views, mat views, comments

### DIFF
--- a/pgadmin_macros/function_get_column_info_schema.sql
+++ b/pgadmin_macros/function_get_column_info_schema.sql
@@ -13,8 +13,6 @@ replacing `sch_name` with `$SELECTION$`.
 use the latest version.
 */
 
-
-
 DROP FUNCTION public.get_column_info_schema(text);
 CREATE OR REPLACE FUNCTION public.get_column_info_schema(IN sch_name text) --$SELECTION$ = schema_name
 
@@ -22,6 +20,7 @@ RETURNS TABLE (
     columns_new_line TEXT,
     columns_no_new_line TEXT,
     columns_no_alias TEXT,
+    object_type TEXT,
     table_schema TEXT,
     tbl_name TEXT,
     table_alias TEXT,
@@ -75,6 +74,11 @@ SELECT
     string_agg(
         pg_attribute.attname, ', ' ORDER BY pg_attribute.attnum
     ) AS columns_no_alias,
+    CASE pg_class.relkind
+        WHEN 'r' THEN 'TABLE'
+        WHEN 'v' THEN 'VIEW'
+        WHEN 'm' THEN 'MATERIALIZED VIEW'
+    END AS object_type,
     pg_namespace.nspname::text AS table_schema,
     pg_class.relname::text AS tbl_name,
     table_prefix.table_alias::text,
@@ -95,7 +99,8 @@ GROUP BY
     pg_namespace.nspname, 
     pg_class.relname,
     table_prefix.table_alias,
-    pg_description.description
+    pg_description.description,
+    pg_class.relkind
 ORDER BY pg_class.relname;
 $$
 LANGUAGE SQL;

--- a/pgadmin_macros/function_get_column_info_schema.sql
+++ b/pgadmin_macros/function_get_column_info_schema.sql
@@ -1,11 +1,19 @@
 /*
-Function to return column names for every table in a schema.
+Function to return column names for every table/view/matview in a schema.
 Copy results to VS Code to take advantage of search/highlighting.
 
-Usage: Set PGadmin Macro SQL to: 
+Usage:
+Option 1: Set PGadmin Macro SQL to: the following:
 --$SELECTION$ = schema_name (eg. rescu)
 SELECT * FROM public.get_column_info_schema('$SELECTION$');
+
+Option 2: Set PGadmin Macro to the body of the below function,
+replacing `sch_name` with `$SELECTION$`.
+- This method will work across databases, but it won't automatically
+use the latest version.
 */
+
+
 
 DROP FUNCTION public.get_column_info_schema(text);
 CREATE OR REPLACE FUNCTION public.get_column_info_schema(IN sch_name text) --$SELECTION$ = schema_name
@@ -16,58 +24,74 @@ RETURNS TABLE (
     columns_no_alias TEXT,
     table_schema TEXT,
     tbl_name TEXT,
-    table_alias TEXT
+    table_alias TEXT,
+    table_comment TEXT
 ) AS
 $$
 
+--$SELECTION$ = schema_name
 WITH table_prefix AS (
     SELECT 
-        p.table_name, 
+        oid, 
         string_agg(
-            LEFT(p.prefix, 1), --first letter of each word in table name
+            LEFT(prefix, 1), --first letter of each word in table name
             ''
         ) AS table_alias
     FROM (
-        SELECT 
-            t.table_name,
+        SELECT
+            pg_class.oid AS oid,
+            pg_class.relname,
             UNNEST( --array to lines
                         regexp_split_to_array(
-                            t.table_name, --extract table name from schema.table_name
+                            pg_class.relname, --extract table name from schema.relname
                             '_'
                         )
             ) prefix
-        FROM information_schema.tables AS t
-        WHERE t.table_schema = sch_name
-    ) AS p
-    GROUP BY p.table_name
+        FROM pg_namespace
+        JOIN pg_catalog.pg_class
+            ON pg_class.relnamespace = pg_namespace.oid
+            AND pg_class.relkind IN ('r', 'v', 'm') --tables, views, mat views
+        WHERE
+            pg_namespace.nspname = sch_name
+    ) AS prefix
+    GROUP BY oid
 )
 
 SELECT 
     string_agg(
-        concat(p.table_alias || '.', c.column_name), 
-        ',' || chr(10)
-        ORDER BY ordinal_position
+        concat(table_prefix.table_alias || '.', pg_attribute.attname), ',' || chr(10)
+        ORDER BY pg_attribute.attnum
     ) AS columns_new_line,
     string_agg(
-        concat(p.table_alias || '.', c.column_name), 
-        ', '
-        ORDER BY ordinal_position
+        concat(table_prefix.table_alias || '.', pg_attribute.attname), ', '
+        ORDER BY pg_attribute.attnum
     ) AS columns_no_new_line,
     string_agg(
-        c.column_name, 
-        ', '
-        ORDER BY ordinal_position
+        pg_attribute.attname, ', ' ORDER BY pg_attribute.attnum
     ) AS columns_no_alias,
-    c.table_schema::text,
-    c.table_name::text AS tbl_name,
-    p.table_alias::text
-FROM information_schema.columns AS c
-JOIN table_prefix AS p ON c.table_name = p.table_name
-WHERE c.table_schema = quote_ident(sch_name)
-GROUP BY 
-    c.table_schema, 
-    c.table_name,
-    p.table_alias
-ORDER BY c.table_name;
+    pg_namespace.nspname::text AS table_schema,
+    pg_class.relname::text AS tbl_name,
+    table_prefix.table_alias::text,
+    pg_description.description AS table_comment
+FROM pg_catalog.pg_namespace
+JOIN pg_catalog.pg_class
+    ON pg_class.relnamespace = pg_namespace.oid
+    AND pg_class.relkind IN ('r', 'v', 'm') --tables, views, mat views
+JOIN pg_catalog.pg_attribute
+    ON pg_class.oid = pg_attribute.attrelid
+    AND pg_attribute.attnum > 0
+    AND NOT attisdropped
+LEFT JOIN pg_catalog.pg_description
+    ON pg_description.objoid = pg_class.oid
+    AND pg_description.objsubid = 0
+JOIN table_prefix ON table_prefix.oid = pg_class.oid
+GROUP BY
+    pg_namespace.nspname, 
+    pg_class.relname,
+    table_prefix.table_alias,
+    pg_description.description
+ORDER BY pg_class.relname;
 $$
 LANGUAGE SQL;
+
+ALTER FUNCTION public.get_column_info_schema OWNER TO dbadmin;

--- a/pgadmin_macros/function_get_column_info_table.sql
+++ b/pgadmin_macros/function_get_column_info_table.sql
@@ -3,9 +3,16 @@ Function to return column names for a single table in a variety of formats
 including as a properlly fluffed SELECT statement with an automatically
 generated alias (first letter of each word in table name ('_' as delimeter))
 
-Usage: Set PGadmin Macro SQL to:
---$SELECTION$ = schema_name.table_name (eg. rescu.volumes_15min)
+Usage:
+Option 1: Set PGadmin Macro SQL to: the following:
+--$SELECTION$ = schema_name.table_name (eg. gis_core.centreline_latest)
 SELECT * FROM public.get_column_info_table('$SELECTION$');
+
+Option 2: Set PGadmin Macro to the body of the below function,
+replacing `sch_table_name` with `$SELECTION$`.
+- This method will work across databases, but it won't automatically
+use the latest version.
+
 */
 
 DROP FUNCTION public.get_column_info_table(text);
@@ -17,61 +24,75 @@ RETURNS TABLE (
     columns_no_alias TEXT,
     table_schema TEXT,
     tbl_name TEXT,
-    table_alias TEXT
+    table_alias TEXT,
+    table_comment TEXT
 ) AS
 $$
 
 --$SELECTION$ = schema_name.table_name
 WITH table_prefix AS (
     SELECT 
-        p.table_name, 
+        oid, 
         string_agg(
-            LEFT(p.prefix, 1), --first letter of each word in table name
+            LEFT(prefix, 1), --first letter of each word in table name
             ''
         ) AS table_alias
     FROM (
-        SELECT 
-            table_name,
+        SELECT
+            pg_class.oid AS oid,
+            pg_class.relname,
             UNNEST( --array to lines
                         regexp_split_to_array(
-                            table_name, --extract table name from schema.table_name
+                            pg_class.relname, --extract table name from schema.relname
                             '_'
                         )
             ) prefix
-        FROM information_schema.tables t
-        WHERE t.table_schema = split_part(sch_table_name, '.', 1)
-            AND t.table_name = split_part(sch_table_name, '.', 2)
-    ) AS p
-    GROUP BY p.table_name
+        FROM pg_namespace
+        JOIN pg_catalog.pg_class
+            ON pg_class.relnamespace = pg_namespace.oid
+            AND pg_class.relkind IN ('r', 'v', 'm') --tables, views, mat views
+        WHERE
+            pg_namespace.nspname = split_part(sch_table_name, '.', 1)
+            AND pg_class.relname = split_part(sch_table_name, '.', 2)
+    ) AS prefix
+    GROUP BY oid
 )
 
 SELECT 
-    'SELECT' || chr(10) || string_agg(
-        concat(p.table_alias || '.', c.column_name), 
-        ',' || chr(10)
-        ORDER BY ordinal_position
-    ) || chr(10) || 'FROM ' || c.table_schema || '.' || c.table_name || ' AS ' || p.table_alias  AS columns_new_line,
-    'SELECT ' || string_agg(
-        concat(p.table_alias || '.', c.column_name), 
-        ','
-        ORDER BY ordinal_position
-    ) || chr(10) || 'FROM ' || c.table_schema || '.' || c.table_name || ' AS ' || p.table_alias  AS columns_no_new_line,
     string_agg(
-        c.column_name, 
-        ', '
-        ORDER BY ordinal_position
+        concat(table_prefix.table_alias || '.', pg_attribute.attname), ',' || chr(10)
+        ORDER BY pg_attribute.attnum
+    ) AS columns_new_line,
+    string_agg(
+        concat(table_prefix.table_alias || '.', pg_attribute.attname), ', '
+        ORDER BY pg_attribute.attnum
+    ) AS columns_no_new_line,
+    string_agg(
+        pg_attribute.attname, ', ' ORDER BY pg_attribute.attnum
     ) AS columns_no_alias,
-    c.table_schema::text,
-    c.table_name::text AS tbl_name,
-    p.table_alias
-FROM information_schema.columns AS c
-JOIN table_prefix AS p ON c.table_name = p.table_name
-WHERE c.table_schema = split_part(sch_table_name, '.', 1)
-    AND c.table_name = split_part(sch_table_name, '.', 2)
-GROUP BY 
-    c.table_schema, 
-    c.table_name,
-    p.table_alias
-ORDER BY c.table_name;
+    pg_namespace.nspname::text AS table_schema,
+    pg_class.relname::text AS tbl_name,
+    table_prefix.table_alias::text,
+    pg_description.description AS table_comment
+FROM pg_catalog.pg_namespace
+JOIN pg_catalog.pg_class
+    ON pg_class.relnamespace = pg_namespace.oid
+    AND pg_class.relkind IN ('r', 'v', 'm') --tables, views, mat views
+JOIN pg_catalog.pg_attribute
+    ON pg_class.oid = pg_attribute.attrelid
+    AND pg_attribute.attnum > 0
+    AND NOT attisdropped
+LEFT JOIN pg_catalog.pg_description
+    ON pg_description.objoid = pg_class.oid
+    AND pg_description.objsubid = 0
+JOIN table_prefix ON table_prefix.oid = pg_class.oid
+GROUP BY
+    pg_namespace.nspname, 
+    pg_class.relname,
+    table_prefix.table_alias,
+    pg_description.description
+ORDER BY pg_class.relname;
 $$
 LANGUAGE SQL;
+
+ALTER FUNCTION public.get_column_info_table OWNER TO dbadmin;

--- a/pgadmin_macros/function_get_column_info_table.sql
+++ b/pgadmin_macros/function_get_column_info_table.sql
@@ -31,32 +31,39 @@ $$
 
 --$SELECTION$ = schema_name.table_name
 WITH table_prefix AS (
-    SELECT 
+    SELECT
         oid, 
         string_agg(
-            LEFT(prefix, 1), --first letter of each word in table name
+            LEFT(word, 1), --first letter of each word in table name
             ''
+            ORDER BY rn
         ) AS table_alias
     FROM (
         SELECT
             pg_class.oid AS oid,
             pg_class.relname,
-            UNNEST( --array to lines
-                        regexp_split_to_array(
-                            pg_class.relname, --extract table name from schema.relname
-                            '_'
-                        )
-            ) prefix
+            table_name.word,
+            table_name.rn
         FROM pg_namespace
         JOIN pg_catalog.pg_class
             ON pg_class.relnamespace = pg_namespace.oid
-            AND pg_class.relkind IN ('r', 'v', 'm') --tables, views, mat views
+            AND pg_class.relkind IN ('r', 'v', 'm'), --tables, views, mat views
+        LATERAL (
+            SELECT
+                regexp_split_to_table,
+                ordinality
+            FROM regexp_split_to_table(
+                pg_class.relname, --extract table name from schema.relname
+                '_'
+            ) WITH ORDINALITY
+        ) AS table_name(word, rn)
         WHERE
             pg_namespace.nspname = split_part(sch_table_name, '.', 1)
             AND pg_class.relname = split_part(sch_table_name, '.', 2)
     ) AS prefix
     GROUP BY oid
 )
+
 
 SELECT 
     string_agg(


### PR DESCRIPTION
These improvements to the macros: 
- include mat views, views in addition to tables
- include object comments
- replace references to information_schema with pg_catalog tables which are more complete. 
- Adds table/view/mat view descriptor to help with mass grant/alter statements

Tested and working!